### PR TITLE
Attempt to convert pochoir FR to WC format

### DIFF
--- a/pochoir/__init__.py
+++ b/pochoir/__init__.py
@@ -12,6 +12,7 @@ from . import plots
 from . import drift
 from . import vtkexport
 from . import srdot
+from . import schema
 
 from .version import version
 

--- a/pochoir/persist.py
+++ b/pochoir/persist.py
@@ -56,3 +56,78 @@ def tempstore(prefix="pochoir-store", fmt='npz'):
             os.unlink(fname)
         else:
             rmtree(fname)
+
+from .schema import FieldResponse, PlaneResponse, PathResponse
+import json
+
+def todict(obj):
+    '''
+    Return a dictionary for the object which is marked up for type.
+    '''
+    for typename in ['FieldResponse', 'PlaneResponse', 'PathResponse']:
+        if typename == type(obj).__name__:
+            cname = obj.__class__.__name__
+            return {cname: {k: todict(v) for k, v in obj._asdict().items()}}
+    if isinstance(obj, numpy.ndarray):
+        shape = list(obj.shape)
+        elements = obj.flatten().tolist()
+        return dict(array=dict(shape=shape, elements=elements))
+    if isinstance(obj, list):
+        return [todict(ele) for ele in obj]
+
+    return obj
+
+
+def fromdict(obj):
+    '''
+    Undo `todict()`.
+    '''
+    if isinstance(obj, dict):
+
+        if 'array' in obj:
+            ret = numpy.asarray(obj['array']['elements'])
+            return ret.reshape(obj['array']['shape'])
+
+        for typ in [FieldResponse, PlaneResponse, PathResponse]:
+            tname = typ.__name__
+            if tname in obj:
+                return typ(**{k: fromdict(v) for k, v in obj[tname].items() if k not in ["pitchdir","wiredir"]})
+
+    if isinstance(obj, list):
+        return [fromdict(ele) for ele in obj]
+
+    return obj
+
+
+def dumps(obj):
+    '''
+    Dump object to JSON text.
+    '''
+    return json.dumps(todict(obj), indent=2)
+
+
+def loads(text):
+    '''
+    Load object from JSON text.
+    '''
+    return fromdict(json.loads(text))
+
+
+def dumpfr(filename, obj):
+    '''
+    Save a response object (typically response.schema.FieldResponse)
+    to a file of the given name.
+    '''
+    text = dumps(obj)
+    if filename.endswith(".json"):
+        open(filename, 'w').write(text)
+        return
+    if filename.endswith(".json.bz2"):
+        import bz2
+        bz2.BZ2File(filename, 'wb').write(text.encode())
+        return
+    if filename.endswith(".json.gz"):
+        import gzip
+        gzip.open(filename, "wb").write(text.encode())
+        return
+    raise ValueError("unknown file format: %s" % filename)

--- a/pochoir/schema.py
+++ b/pochoir/schema.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+'''This module defines an object schema which strives to be generic
+enough to describe various sets of field responses including:
+
+    - 1D :: responses which do not extend to inter-pitch regions and
+      have no intra-pitch variation.  Responses come from averaged 2D
+      field calculations, eg with Garfield.  This is the type
+      originally used for LArSoft simulation and deconvoultion for
+      some time.
+
+    - 2D :: responses defined on drift paths starting from
+      fine-grained points on a line perpendicular to drift and wire
+      directions and which spans multiple wire regions.  Responses
+      come from 2D field calculations, eg with Garfield.  This is the
+      type used in the Wire Cell simulation as developed by Xiaoyue Li
+      and Wire Cell deconvolution as developed by Xin Qian.
+
+    - 2.5D :: not supported directly by this schema but 2D responses
+      can be made by an average over 2D slices made perpendicular to
+      wires/strips in each plane.  These slices may hold 2D field
+      calculations or be slices of 3D calculations.  In either case,
+      some form of average along the wire/strip direction collapses
+      the dimensionality to 2D.
+
+    - 3D :: not supported directly by this schema, but responses
+      defined on drift paths starting from fine-grained points on a
+      plane perpendicular to nominal drift direction and spanning
+      multiple wire regions.  Responses come from 3D field
+      calculations, eg with LARF.  Simulation and deconvolution using
+      these type of responses are not yet developed.
+
+The schema is defined through a number of `namedtuple` collections.
+
+Units Notice: any attributes of these classes which are quantities
+with units must be in Wire Cell system of units.
+
+Coordinate System Notice: X-axis is along the direction counter to the
+nominal electron drift, Y-axis is upward, against gravity, Z-axis
+follows from the right-handed cross product of X and Y.  The X-origin
+is arbitrary.  In Wire Cell the convention is to take the "location"
+of the last (collection) plane (but beware for possible deviations).
+A global, transverse origin is not specified but each path response is
+at a transverse location given in terms of wire and pitch distances
+(positions).  In Wire Cell an origin is set from which these are to be
+measured.
+
+'''
+
+from collections import namedtuple
+
+class FieldResponse(namedtuple("FieldResponse","planes axis origin tstart period speed")):
+    '''
+    :param list planes: List of PlaneResponse objects.
+    :param list axis: A normalized 3-vector giving direction of axis
+        (anti)parallel to nominal drift direction.
+    :param float origin: location along the X-axis where drift paths
+        begin (see PlaneResponse.location).
+    :param float tstart: the time at which drift paths are considered
+        to begin.
+    :param float period: the sampling period of the field response.
+    :param float speed: the nominal drift speed used in the
+        calculation.
+    '''
+    __slots__ = ()
+
+
+
+
+class PlaneResponse(namedtuple("PlaneResponse","paths planeid location pitch")):
+    '''
+    :param list paths: List of PathResponse objects.  These MUST be sorted by pitchpos!
+    :param int planeid: A numerical identifier for the plane,
+        typically [0,1,2].
+    :param float location: Location in drift direction of this plane
+        (see FieldResponse.origin).
+    :param float pitch: The uniform wire pitch used for the path
+        responses of this plane.
+    '''
+    __slots__ = ()
+    
+
+class PathResponse(namedtuple("PathResponse", "current pitchpos wirepos")):
+    '''
+    :param array current: A numpy array holding the induced current
+        for the path on the wire-of-interest.
+    :param float pitchpos: The position in the pitch direction to the
+        starting point of the path.
+    :param float wirepos: The position along the wire direction to the
+        starting point of the path.
+
+        Note: the path is in wire region: 
+
+        region = int(round(pitchpos/pitch)).
+
+        Note: the path is at the impact position relative to closest
+        wire: 
+
+        impact = pitchpos-region*pitch.
+    '''
+    __slots__ = ()
+
+

--- a/test/example_converter_config.json
+++ b/test/example_converter_config.json
@@ -1,0 +1,16 @@
+{
+    "tstart" : 0.0,
+    "origin" : 200.0,
+    "speed" : 0.0016,
+    "period" : 100.0,
+    "starting_wire_pitch" : -17.5,
+    "stripLength" : 5,
+    "npaths" : 6,
+    "totstrip" : 7,
+    "planeUlocation" : 3.2,
+    "planeUpitch" : 5.0,
+    "planeVlocation" : 3.2,
+    "planeVpitch" : 5.0,
+    "planeWlocation" : 0,
+    "planeWpitch" : 5.0
+}

--- a/test/test-full-3d-50L.sh
+++ b/test/test-full-3d-50L.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+
+#tdir="$(dirname $(realpath $BASH_SOURCE))"
+
+export POCHOIR_STORE="${1:-store}"
+
+source helpers.sh
+
+
+## Domains ##
+do_domain () {
+    local name=$1 ; shift
+    local shape=$1; shift
+    local spacing=$1; shift
+
+    want domain/$name \
+         pochoir domain --domain domain/$name \
+         --shape=$shape --spacing $spacing
+}
+do_domain drift3d  25,17,700  '0.1*mm'
+
+# fixme: these weight* identifiers need to split up for N planes.
+do_domain weight2d 1092,700   '0.1*mm'
+do_domain weight3d 350,32,700 '0.1*mm'
+
+
+## Initial/Boundary Value Arrays ##
+do_gen () {
+    local name=$1 ; shift
+    local geom=$1; shift
+    local gen="pcb_$geom"
+    local cfg="example_gen_pcb_${geom}_config.json"
+
+    want initial/$name \
+         pochoir gen --generator $gen --domain domain/$name \
+         --initial initial/$name --boundary boundary/$name \
+         $cfg
+
+}
+do_gen drift3d quarter
+do_gen weight2d 2D
+do_gen weight3d 3D
+
+## Fields
+do_fdm () {
+    local name=$1 ; shift
+    local nepochs=$1 ; shift
+    local epoch=$1 ; shift
+    local prec=$1 ; shift
+    local edges=$1 ; shift
+
+    want potential/$name \
+         pochoir fdm \
+         --nepochs $nepochs --epoch $epoch --precision $prec \
+         --edges $edges \
+         --initial initial/$name --boundary boundary/$name \
+         --potential potential/$name \
+         --increment increment/$name
+}
+do_fdm drift3d  4      5000000      0.0000000002     fix,fix,fix
+do_fdm weight2d 2      5000000      0.0000000002    fix,fix
+
+# special step to form iva/bva from 2D solution
+want initial/weight3dfull \
+     pochoir bc-interp --xcoord '17.5*mm' \
+     --initial initial/weight3dfull --boundary boundary/weight3dfull \
+     --initial3d initial/weight3d --boundary3d boundary/weight3d \
+     --potential2d potential/weight2d
+
+do_fdm weight3dfull 1      5000000      0.0000000002      fix,per,fix
+
+
+want velocity/drift3d \
+     pochoir velo --temperature '89*K' \
+     --potential potential/drift3d \
+     --velocity velocity/drift3d
+
+want starts/drift3d \
+    pochoir starts --starts starts/drift3d \
+    '0.05*mm,0.05*mm,198*mm' '0.05*mm,0.2*mm,198*mm' '0.05*mm,0.35*mm,198*mm' '0.05*mm,0.5*mm,198*mm' '0.05*mm,0.65*mm,198*mm' '0.05*mm,0.8*mm,198*mm' '0.05*mm,0.95*mm,198*mm' '0.05*mm,1.1*mm,198*mm' '0.05*mm,1.25*mm,198*mm' '0.05*mm,1.4*mm,198*mm' '0.05*mm,1.55*mm,198*mm' '0.51*mm,0.05*mm,198*mm' '0.51*mm,0.2*mm,198*mm' '0.51*mm,0.35*mm,198*mm' '0.51*mm,0.5*mm,198*mm' '0.51*mm,0.65*mm,198*mm' '0.51*mm,0.8*mm,198*mm' '0.51*mm,0.95*mm,198*mm' '0.51*mm,1.1*mm,198*mm' '0.51*mm,1.25*mm,198*mm' '0.51*mm,1.4*mm,198*mm' '0.51*mm,1.55*mm,198*mm' '0.97*mm,0.05*mm,198*mm' '0.97*mm,0.2*mm,198*mm' '0.97*mm,0.35*mm,198*mm' '0.97*mm,0.5*mm,198*mm' '0.97*mm,0.65*mm,198*mm' '0.97*mm,0.8*mm,198*mm' '0.97*mm,0.95*mm,198*mm' '0.97*mm,1.1*mm,198*mm' '0.97*mm,1.25*mm,198*mm' '0.97*mm,1.4*mm,198*mm' '0.97*mm,1.55*mm,198*mm' '1.43*mm,0.05*mm,198*mm' '1.43*mm,0.2*mm,198*mm' '1.43*mm,0.35*mm,198*mm' '1.43*mm,0.5*mm,198*mm' '1.43*mm,0.65*mm,198*mm' '1.43*mm,0.8*mm,198*mm' '1.43*mm,0.95*mm,198*mm' '1.43*mm,1.1*mm,198*mm' '1.43*mm,1.25*mm,198*mm' '1.43*mm,1.4*mm,198*mm' '1.43*mm,1.55*mm,198*mm' '1.89*mm,0.05*mm,198*mm' '1.89*mm,0.2*mm,198*mm' '1.89*mm,0.35*mm,198*mm' '1.89*mm,0.5*mm,198*mm' '1.89*mm,0.65*mm,198*mm' '1.89*mm,0.8*mm,198*mm' '1.89*mm,0.95*mm,198*mm' '1.89*mm,1.1*mm,198*mm' '1.89*mm,1.25*mm,198*mm' '1.89*mm,1.4*mm,198*mm' '1.89*mm,1.55*mm,198*mm' '2.35*mm,0.05*mm,198*mm' '2.35*mm,0.2*mm,198*mm' '2.35*mm,0.35*mm,198*mm' '2.35*mm,0.5*mm,198*mm' '2.35*mm,0.65*mm,198*mm' '2.35*mm,0.8*mm,198*mm' '2.35*mm,0.95*mm,198*mm' '2.35*mm,1.1*mm,198*mm' '2.35*mm,1.25*mm,198*mm' '2.35*mm,1.4*mm,198*mm' '2.35*mm,1.55*mm,198*mm'
+
+want paths/drift3d \
+     pochoir drift --starts starts/drift3d \
+     --velocity velocity/drift3d \
+     --paths paths/drift3d '0*us,4250*us,0.1*us'
+
+
+want current/induced_current_avg \
+     pochoir induce --weighting potential/weight3dfull \
+     --paths paths/drift3d \
+     --output current/induced_current_avg \
+     --average 11.0 \
+     --nstrips 7.0
+     
+want pochoir convertfr -u current/induced_current_avg_U -v current/induced_current_avg_U -w current/induced_current_avg_W -O fr.json example_converter_config.json
+
+


### PR DESCRIPTION
Several functions are introduced:
1)extendwf is expected to extend +-3 wires used in weighting field 3D simulation to +-10 using 2D case. Although code works as intended it needs more testing as a concept
2)induce command to calculate current is extended and now can average along strip direction and copy paths around to the naiboring strtips. Currently works only for 50L geometry
3)convertfr converts pochoir current from induced command to WC format (NOTE: some cheeting based on 50L symmetry, can be more general)

Also includes sevaral changes to persist (to dump FR in json format) and schema files copied from wire-cell-python

test directory includes example config file for convertfr function and test-full-3d-50L.sh executable to run full 50L chain